### PR TITLE
Update to sfml 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "snake"
 
 [dependencies]
 rand = "0.7.2"
-sfml = { version = "0.15.1", optional = true }
+sfml = { version = "0.16.0", optional = true }
 indexmap = "1.3.2"
 
 [dev-dependencies]

--- a/examples/game.rs
+++ b/examples/game.rs
@@ -1,45 +1,36 @@
 use sfml::window::Key;
 use snake::{Direction, RenderWindow, Snake, Style};
-use std::sync::{Arc, Mutex};
-use std::{thread, time};
+use std::time::{Duration, Instant};
 
 fn main() {
     let window = RenderWindow::new((1000, 1000), "Snake", Style::CLOSE, &Default::default());
 
     let mut game = Snake::new_display(0, 15, Some(window));
-    let direction = Arc::new(Mutex::new(Direction::Center));
-    let dir = direction.clone();
-
-    // Thread to handle user input
-    thread::spawn(move || loop {
-        let mut dir = dir.lock().unwrap();
-        *dir = if Key::Up.is_pressed() {
-            Direction::Up
-        } else if Key::Down.is_pressed() {
-            Direction::Down
-        } else if Key::Left.is_pressed() {
-            Direction::Left
-        } else if Key::Right.is_pressed() {
-            Direction::Right
-        } else {
-            *dir
-        };
-        drop(dir);
-        let delay = time::Duration::from_millis(10);
-        thread::sleep(delay);
-    });
+    let mut direction = Direction::Center;
+    let mut last_turn = Instant::now();
 
     loop {
-        let direction = direction.lock().unwrap();
-        let val = *direction;
-        if *direction == Direction::Center {
+        // Handle user input
+        direction = if Key::UP.is_pressed() {
+            Direction::Up
+        } else if Key::DOWN.is_pressed() {
+            Direction::Down
+        } else if Key::LEFT.is_pressed() {
+            Direction::Left
+        } else if Key::RIGHT.is_pressed() {
+            Direction::Right
+        } else {
+            direction
+        };
+        let val = direction;
+        if direction == Direction::Center {
             continue;
         }
-        drop(direction);
-        if !game.turn(val) {
-            return;
+        if last_turn.elapsed() > Duration::from_millis(250) {
+            if !game.turn(val) {
+                return;
+            }
+            last_turn = Instant::now();
         }
-        let delay = time::Duration::from_millis(250);
-        thread::sleep(delay);
     }
 }


### PR DESCRIPTION
https://github.com/jeremyletang/rust-sfml/releases/tag/v0.16.0

Since Window must be used on the main thread, the game loop was
refactored to be single-threaded instead of input handling being in
a different thread.